### PR TITLE
Update `job` context example to include `check_run_id`

### DIFF
--- a/content/actions/reference/workflows-and-actions/contexts.md
+++ b/content/actions/reference/workflows-and-actions/contexts.md
@@ -378,11 +378,12 @@ The `job` context contains information about the currently running job.
 
 ### Example contents of the `job` context
 
-This example `job` context uses a PostgreSQL service container with mapped ports. If there are no containers or service containers used in a job, the `job` context only contains the `status` property.
+This example `job` context uses a PostgreSQL service container with mapped ports. If there are no containers or service containers used in a job, the `job` context only contains the `status` and `check_run_id` properties.
 
 ```json
 {
   "status": "success",
+  {% ifversion fpt or ghec %}"check_run_id": 51725241954,{% endif %}
   "container": {
     "network": "github_network_53269bd575974817b43f4733536b200c"
   },


### PR DESCRIPTION
Added 'check_run_id' property to job context example.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #40669

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Update `job` context example to include newly added property `check_run_id`.

The example `check_run_id` value is taken from this [run](https://github.com/dhimmel/dump-actions-context/actions/runs/18170960955/job/51725241954#step:5:9), see also its [persistent file](https://github.com/dhimmel/dump-actions-context/blob/9a0b80d9e37259e3a6ee9526f64391eaa684026b/contexts/schedule.gron#L160).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
